### PR TITLE
Make pdf2json async

### DIFF
--- a/lib/pdf2json.js
+++ b/lib/pdf2json.js
@@ -1,30 +1,12 @@
-var crf = require('./cmap-reader-factory.js');
-var pdfJs = require('./pdf.js');
-pdfJs.PDFJS.workerSrc = './pdf.worker.js';
+const root = __dirname + '/../../';
+var crf = require(root + 'src/core/cmap-reader-factory.js');
+
+var pdfJs = require(root + 'lib/pdf.js');
+pdfJs.PDFJS.workerSrc = root + 'lib/pdf.worker.js';
 pdfJs.PDFJS.disableWorker = false;
 
-pdfJs.PDFJS.cMapUrl = __dirname + '/../lib/cmaps/';
+pdfJs.PDFJS.cMapUrl = root + 'lib/cmaps/';
 pdfJs.PDFJS.cMapPacked = true;
-
-function timeoutCallbackWrapper(callback, timeout) {
-    if(!timeout){
-        timeout = 10000;
-    }
-    var isCalled = false;
-    var timer = setTimeout(() => {
-        if (!isCalled) {
-            callback(null, new Error('timeout after ' + timeout + ' ms'));
-            isCalled = true;
-        }
-    }, timeout);
-    return (err, result) => {
-        if (!isCalled) {
-            isCalled = true;
-            clearTimeout(timer);
-            return callback(result, err);
-        }
-    };
-}
 
 function composePdfSource(src) {
     var source;
@@ -42,23 +24,20 @@ function composePdfSource(src) {
     );
 }
 
-function pdf2json(pdfPath, callback) {
-    // wrap callback to ensure one-off and set timeout
-    var callback = timeoutCallbackWrapper(callback);
-
-    pdfJs.getDocument(
+async function pdf2json(pdfPath) {
+    return pdfJs.getDocument(
         composePdfSource(pdfPath)
-    ).then((document) => {
+    ).then(async (document) => {
         var pdf = {pages: []};
         for (var i = 1; i <= document.pdfInfo.numPages; i++) {
-            document.getPage(i).then(documentPage => {
+            await document.getPage(i).then(async (documentPage) => {
                 var page = {
                     width: documentPage.pageInfo.view[2],
                     height: documentPage.pageInfo.view[3],
                     pageId: -1,
                     texts: [],
                 };
-                documentPage.getTextContent().then(textContent => {
+                await documentPage.getTextContent().then(async (textContent) => {
                     if (textContent.items.length != 0) {
                         page.pageId = parseInt(textContent.items[0].pageId);
                     }
@@ -82,23 +61,11 @@ function pdf2json(pdfPath, callback) {
                         }));
                 }).then(() => {
                     pdf.pages.push(page);
-                    // callback result when pages is fullfilled
-                    if (pdf.pages.length === document.pdfInfo.numPages) {
-                        callback(pdf, null)
-                    }
-                }).catch((error) => {
-                    // error in getTextContent promise chain
-                    callback(null, error);
-                });
-            }).catch((error) => {
-                // error in getPage promise
-                callback(null, error);
-            });
+                })
+            })
         }
-    }).catch((error) => {
-        // error in getDocument promise chain
-        callback(null, error);
-    });
+        return pdf; 
+    })
 };
 
 exports.pdf2json = pdf2json;

--- a/src/pdf2json/pdf2json.js
+++ b/src/pdf2json/pdf2json.js
@@ -8,26 +8,6 @@ pdfJs.PDFJS.disableWorker = false;
 pdfJs.PDFJS.cMapUrl = root + 'lib/cmaps/';
 pdfJs.PDFJS.cMapPacked = true;
 
-function timeoutCallbackWrapper(callback, timeout) {
-    if(!timeout){
-        timeout = 10000;
-    }
-    var isCalled = false;
-    var timer = setTimeout(() => {
-        if (!isCalled) {
-            callback(null, new Error('timeout after ' + timeout + ' ms'));
-            isCalled = true;
-        }
-    }, timeout);
-    return (err, result) => {
-        if (!isCalled) {
-            isCalled = true;
-            clearTimeout(timer);
-            return callback(result, err);
-        }
-    };
-}
-
 function composePdfSource(src) {
     var source;
     if (typeof src === 'string') {
@@ -44,28 +24,25 @@ function composePdfSource(src) {
     );
 }
 
-function pdf2json(pdfPath, callback) {
-    // wrap callback to ensure one-off and set timeout
-    var callback = timeoutCallbackWrapper(callback);
-
-    pdfJs.getDocument(
+async function pdf2json(pdfPath) {
+    return pdfJs.getDocument(
         composePdfSource(pdfPath)
-    ).then((document) => {
+    ).then(async (document) => {
         var pdf = {pages: []};
         for (var i = 1; i <= document.pdfInfo.numPages; i++) {
-            document.getPage(i).then(documentPage => {
+            await document.getPage(i).then(async (documentPage) => {
                 var page = {
                     width: documentPage.pageInfo.view[2],
                     height: documentPage.pageInfo.view[3],
                     pageId: -1,
                     texts: [],
                 };
-                documentPage.getTextContent().then(textContent => {
+                await documentPage.getTextContent().then(async (textContent) => {
                     if (textContent.items.length != 0) {
                         page.pageId = parseInt(textContent.items[0].pageId);
                     }
                     page.texts = textContent.items
-                        .filter(item => item.str != null && item.str != "" && item.str !=" ")
+                        .filter(item => item.str != null && item.str != "")
                         .map(item => ({
                             text: item.str,
                             direction: item.dir,
@@ -84,23 +61,11 @@ function pdf2json(pdfPath, callback) {
                         }));
                 }).then(() => {
                     pdf.pages.push(page);
-                    // callback result when pages is fullfilled
-                    if (pdf.pages.length === document.pdfInfo.numPages) {
-                        callback(pdf, null)
-                    }
-                }).catch((error) => {
-                    // error in getTextContent promise chain
-                    callback(null, error);
-                });
-            }).catch((error) => {
-                // error in getPage promise
-                callback(null, error);
-            });
+                })
+            })
         }
-    }).catch((error) => {
-        // error in getDocument promise chain
-        callback(null, error);
-    });
+        return pdf; 
+    })
 };
 
 exports.pdf2json = pdf2json;


### PR DESCRIPTION
Hi, 

Thanks for the amazing work with this package. 
I personally needed to make the pdf2json function async since waiting for a callback is not the best method to wait for the result. 

This is surely a breaking change but maybe one you should consider. 

I also don't understand why there is almost two version of each file. 